### PR TITLE
fix: data.sql 의존성 문제 해결(순서에 맞는 데이터 생성)

### DIFF
--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,3 +1,7 @@
+# 의존성이 있는 질의어는 트랜잭션 단위로 묶어서 COMMIT
+# 예시 : INSERT B가 INSERT A에 의존하는(후행하는) 경우 {START TRANSACTION, INSERT A, INSERT B, COMMIT}
+START TRANSACTION;
+
 # 외래키 제약조건으로 인해 region 테이블을 먼저 생성해야 한다.
 INSERT INTO region (zcode, region_name)
 VALUES
@@ -268,3 +272,5 @@ VALUES ('11', '11110', '종로구'),
        ('51', '51810', '인제군'),
        ('51', '51820', '고성군'),
        ('51', '51830', '양양군');
+
+COMMIT;


### PR DESCRIPTION
## 작업 내역
- [x] data.sql 테이블 별 의존성에 맞춰 순서대로 질의어 실행되게 수정


## 참고사항
* 이후 의존성 있는 테이블 데이터 조작 시 `START TRANSACTION`, `COMMIT`으로 트랜잭션 단위로 그룹핑
* close #27 
