### PR TITLE
카카오 로그인 (#78)

### DIFF
--- a/front/src/components/AuthContext.js
+++ b/front/src/components/AuthContext.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, createContext, useContext } from 'react';
 import axios from 'axios';
 import { HttpGet, HttpPost } from '../services/HttpService';
+import UsernameStorage from './UsernameStorage';
 const AuthContext = createContext();
 
 export const AuthProvider = ({ children }) => {
 const [user, setUser] = useState(null);
-
 const setLogined = (userData) => {
     setUser(userData);
 };
@@ -13,14 +13,12 @@ const setLogined = (userData) => {
 const setLogout = async () => {
     HttpPost('/api/v1/members/logout');
     sessionStorage.removeItem("username");
-    
+
     setUser(null);
 };
-
 const isLogin = () => {
     return user !== null;
 };
-
 const isLogout = () => {
     return user === null;   
 };
@@ -36,7 +34,7 @@ const initAuth = async () => {
     .then((data) => {
         console.log('memeber me ' + data)
         if(data){
-            setLogined(data.item);
+            setLogined(data.data.item);
         }
     });
 };
@@ -44,27 +42,30 @@ const initAuth = async () => {
 const getUserName = () => {
     return user ? user.username : null;
 };
-
 const getUserPermissions = () => {
 return user ? user.authorities : [];
 };
-
 const getUserId = () => {
     return user ? user.id : null;
 };
+
+const getUserNickname = () => {
+    return user ? user.nickname : null;
+}
 
 //useEffect는 컴포넌트 마운트 될때 한번 실행됨
 useEffect(() => {
     initAuth();
 }, []);
-
 return (
-    <AuthContext.Provider value={{ user, setLogined, setLogout, isLogin, isLogout, getUserName, getUserPermissions, getUserId  }}>
+    <>
+    <UsernameStorage></UsernameStorage>
+    <AuthContext.Provider value={{ user, setLogined, setLogout, isLogin, isLogout, getUserName, getUserPermissions, getUserId, getUserNickname  }}>
         {children}
     </AuthContext.Provider>
+    </>
     );
 };
-
 export const useAuth = () => {
     const context = useContext(AuthContext);
     if (context === undefined) {

--- a/front/src/components/KakaoLoginButton.js
+++ b/front/src/components/KakaoLoginButton.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+const KakaoLoginButton = () =>{
+  
+  const redirectUrl = "http://localhost:3000";
+  
+
+  
+  // 클릭 이벤트 핸들러
+  const handleClick = () => {
+    window.location.href = `${process.env.REACT_APP_BACKEND_URL}/socialLogin/kakao?redirectUrl=${encodeURIComponent(process.env.REACT_APP_FRONT_URL)}`;
+  };
+
+  return (
+    <div>
+      <button onClick={handleClick}>카카오 로그인</button>
+    </div>
+  );
+}
+
+export default KakaoLoginButton;

--- a/front/src/components/UsernameStorage.js
+++ b/front/src/components/UsernameStorage.js
@@ -1,0 +1,22 @@
+import { useEffect } from "react"
+import { useLocation } from "react-router-dom"
+
+const UsernameStorage = () => {
+    const location = useLocation();
+
+    useEffect(() => {
+        //url에서 쿼리 파라미터 파싱
+        const queryParams = new URLSearchParams(location.search);
+        const username = queryParams.get('kakaousername');
+
+        if(username){
+            sessionStorage.setItem('username', username);
+            console.log('usernameStorage');
+        }
+    }, [location]);
+
+    return null;
+};
+
+export default UsernameStorage;
+

--- a/front/src/layout/NavBar.js
+++ b/front/src/layout/NavBar.js
@@ -2,11 +2,18 @@ import React from "react";
 import { AppBar, Toolbar, Typography, Button } from "@material-ui/core";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuth } from "../components/AuthContext";
+import UsernameStorage from "../components/UsernameStorage";
+
 
 const Navbar = () => {
   const navigate = useNavigate();
 
-  const { isLogin, setLogout, getUserName } = useAuth();
+  const { isLogin, setLogout, getUserName, getUserNickname } = useAuth();
+  console.log('useAuth ?? ')
+  console.log(useAuth());
+
+  console.log(useAuth().getUserName());
+  
 
   const handleLogout = () => {
     setLogout();
@@ -39,7 +46,7 @@ const Navbar = () => {
         {isLogin() ? ( // 로그인된 상태일 때
           <>
             <Typography variant="body1" style={{ marginRight: "1rem" }}>
-              {getUserName()}님 환영합니다.{" "}
+              {!getUserName().startsWith("KAKAO") ? getUserName() : getUserNickname()}님 환영합니다.{" "}
               {/* 로그인된 사용자의 이름을 보여줌 */}
             </Typography>
             <Button color="inherit" onClick={handleLogout}>

--- a/front/src/pages/Login/Login.js
+++ b/front/src/pages/Login/Login.js
@@ -2,7 +2,9 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../components/AuthContext';
+import KakaoLoginButton from '../../components/KakaoLoginButton';
 import { HttpGet, HttpPost } from '../../services/HttpService';
+
 const Login = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -10,11 +12,15 @@ const Login = () => {
   const { setLogined } = useAuth();
   const handleLogin = async () => {
     try {
+
       HttpPost(
         '/api/v1/members/login',
         {
           username: username,
           password: password,
+        },
+        {
+          withCredentials: true, // credentials include 옵션 추가
         }
       ).then((response) => {
        // 로그인 성공 시 처리
@@ -67,6 +73,7 @@ const Login = () => {
           Login
         </button>
       </form>
+      <KakaoLoginButton>카카오 로그인</KakaoLoginButton>
     </div>
   );
 };

--- a/src/main/java/com/ll/eitcharge/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/ll/eitcharge/domain/member/member/controller/MemberController.java
@@ -41,6 +41,11 @@ public class MemberController {
         rq.setCrossDomainCookie("refreshToken", authAndMakeTokensRs.getData().refreshToken());
         rq.setCrossDomainCookie("accessToken", authAndMakeTokensRs.getData().accessToken());
 
+        RsData< LoginResponseBody > loginResponseBodyRsData = authAndMakeTokensRs.newDataOf(
+                new LoginResponseBody(
+                        new MemberDto(authAndMakeTokensRs.getData().member())
+                )
+        );
         return authAndMakeTokensRs.newDataOf(
                 new LoginResponseBody(
                         new MemberDto(authAndMakeTokensRs.getData().member())

--- a/src/main/java/com/ll/eitcharge/domain/member/member/controller/SocialMemberController.java
+++ b/src/main/java/com/ll/eitcharge/domain/member/member/controller/SocialMemberController.java
@@ -1,0 +1,34 @@
+package com.ll.eitcharge.domain.member.member.controller;
+
+import com.ll.eitcharge.global.rq.Rq;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.Cookie;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequiredArgsConstructor
+public class SocialMemberController {
+    private final Rq rq;
+
+    @GetMapping("/socialLogin/{providerTypeCode}")
+    public String socialLogin(String redirectUrl, @PathVariable String providerTypeCode) {
+        if (rq.isFrontUrl(redirectUrl)) {
+            rq.setCookie("redirectUrlAfterSocialLogin", redirectUrl, 60 * 10);
+        }
+
+        return "redirect:/oauth2/authorization/" + providerTypeCode;
+    }
+
+    @GetMapping("/")
+    public String main(){
+        String redirectUrlAfterSocialLogin = rq.getCookie("redirectUrlAfterSocialLogin").getValue();
+
+        return "redirect:"+ redirectUrlAfterSocialLogin;
+    }
+
+
+}

--- a/src/main/java/com/ll/eitcharge/domain/member/member/dto/MemberDto.java
+++ b/src/main/java/com/ll/eitcharge/domain/member/member/dto/MemberDto.java
@@ -5,6 +5,7 @@ import static lombok.AccessLevel.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.lang.NonNull;
 
 import com.ll.eitcharge.domain.member.member.entity.Member;
@@ -24,6 +25,10 @@ public class MemberDto {
     private String username;
     @NonNull
     private List<String> authorities;
+    @NonNull
+    private String nickname;
+    @NotNull
+    private String profileImgUrl;
 
     public MemberDto(Member member) {
         this.id = member.getId();
@@ -31,5 +36,7 @@ public class MemberDto {
         this.modifyDate = member.getModifiedDate();
         this.username = member.getUsername();
         this.authorities = member.getAuthoritiesAsStringList();
+        this.nickname = member.getNickname();
+        this.profileImgUrl = member.getProfileImgUrl();
     }
 }

--- a/src/main/java/com/ll/eitcharge/domain/member/member/entity/Member.java
+++ b/src/main/java/com/ll/eitcharge/domain/member/member/entity/Member.java
@@ -40,6 +40,9 @@ public class Member extends BaseTime {
     @OneToMany(mappedBy = "member")
     private List<Review> reviews = new ArrayList<>();
 
+    private String nickname;
+    private String profileImgUrl;
+
     @Transient
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return getAuthoritiesAsStringList()
@@ -80,5 +83,10 @@ public class Member extends BaseTime {
     @Transient
     public void setAdmin(boolean admin) {
         this._isAdmin = admin;
+    }
+
+    public void changeNickNameAndProfileImgUrl(String nickname, String profileImgUrl) {
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
     }
 }

--- a/src/main/java/com/ll/eitcharge/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/ll/eitcharge/domain/member/member/service/MemberService.java
@@ -35,6 +35,35 @@ public class MemberService {
         return RsData.of("%s님 환영합니다. 회원가입이 완료되었습니다. 로그인 후 이용해주세요.".formatted(member.getUsername()), member);
     }
 
+    @Transactional
+    public RsData<Member> join(String username, String password, String nickname, String profileImgUrl) {
+        Member member = Member.builder()
+                .username(username)
+                .password(passwordEncoder.encode(password))
+                .refreshToken(authTokenService.genRefreshToken())
+                .nickname(nickname)
+                .profileImgUrl(profileImgUrl)
+                .build();
+        memberRepository.save(member);
+
+        return RsData.of("%s님 환영합니다. 회원가입이 완료되었습니다. 로그인 후 이용해주세요.".formatted(member.getUsername()), member);
+    }
+
+    @Transactional
+    public RsData<Member> modifyOrJoin(String username, String providerTypeCode, String nickname, String profileImgUrl){
+        Member member = findByUsername(username).orElse(null);
+        if(member == null){
+            return join(username, "", nickname, profileImgUrl);
+        }
+        return modifyNicknameAndProfile(member, nickname, profileImgUrl);
+    }
+
+    @Transactional
+    public RsData<Member> modifyNicknameAndProfile(Member member, String nickname, String profileImgUrl){
+        member.changeNickNameAndProfileImgUrl(nickname, profileImgUrl);
+        return RsData.of("200", "ok", member);
+    }
+
     public Optional<Member> findByUsername(String username) {
         return memberRepository.findByUsername(username);
     }
@@ -110,4 +139,6 @@ public class MemberService {
 
         return RsData.of("200-1", "토큰 갱신 성공", accessToken);
     }
+
+
 }

--- a/src/main/java/com/ll/eitcharge/global/rq/Rq.java
+++ b/src/main/java/com/ll/eitcharge/global/rq/Rq.java
@@ -158,6 +158,7 @@ public class Rq {
         if (isLogout()) return null;
 
         if (member == null) {
+            System.out.println(getUser().getId());
             // entityManager 객체로 프록시 객체 얻기
             member = entityManager.getReference(Member.class, getUser().getId());
             member.setAdmin(isAdmin());
@@ -211,5 +212,13 @@ public class Rq {
         removeCrossDomainCookie("accessToken");
         removeCrossDomainCookie("refreshToken");
         SecurityContextHolder.getContext().setAuthentication(null);
+    }
+
+    public boolean isFrontUrl(String url){
+        return url.startsWith(AppConfig.getSiteFrontUrl());
+    }
+
+    public void destroySession(){
+        req.getSession().invalidate();
     }
 }

--- a/src/main/java/com/ll/eitcharge/global/security/ASuccessHandler.java
+++ b/src/main/java/com/ll/eitcharge/global/security/ASuccessHandler.java
@@ -1,0 +1,84 @@
+package com.ll.eitcharge.global.security;
+
+import com.ll.eitcharge.domain.member.member.entity.Member;
+import com.ll.eitcharge.domain.member.member.service.AuthTokenService;
+import com.ll.eitcharge.domain.member.member.service.MemberService;
+import com.ll.eitcharge.global.rq.Rq;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+
+@Component
+@RequiredArgsConstructor
+public class ASuccessHandler implements AuthenticationSuccessHandler {
+
+    private final AuthTokenService authTokenService;
+    private final MemberService memberService;
+    private final Rq rq;
+
+    @Value("${custom.dev.frontUrl}")
+    private String frontUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
+        Member member = memberService.findByUsername(authentication.getName()).get();
+        String accessToken = authTokenService.genAccessToken(member);
+        String refreshToken = member.getRefreshToken();
+
+
+        String redirectUrlAfterSocialLogin = rq.getCookieValue("redirectUrlAfterSocialLogin", "");
+
+        ResponseCookie accessTokenCookie = ResponseCookie.from("accessToken", accessToken)
+                .path("/")
+                .domain("localhost")
+                .sameSite("Strict")
+                .secure(true)
+                .httpOnly(true)
+                .build();
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .path("/")
+                .domain("localhost")
+                .sameSite("Strict")
+                .secure(true)
+                .httpOnly(true)
+                .build();
+
+        response.addHeader("Set-Cookie", accessTokenCookie.toString());
+        response.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+
+        Cookie[] cookies = request.getCookies();
+
+        Cookie cookie1 = null;
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(redirectUrlAfterSocialLogin)) {
+                cookie1 = cookie;
+            }
+        }
+
+
+        if (cookie1 != null) {
+            cookie1.setPath("/");
+            cookie1.setMaxAge(0);
+            response.addCookie(cookie1);
+        }
+
+        String userName = member.getName();
+        String redirectUrlWithUsername = frontUrl + "?kakaousername=" + URLEncoder.encode(userName, "UTF-8");
+
+        response.sendRedirect(redirectUrlWithUsername);
+    }
+}

--- a/src/main/java/com/ll/eitcharge/global/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/ll/eitcharge/global/security/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,39 @@
+package com.ll.eitcharge.global.security;
+
+import com.ll.eitcharge.domain.member.member.service.AuthTokenService;
+import com.ll.eitcharge.global.rq.Rq;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+    private final Rq rq;
+    private final AuthTokenService authTokenService;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException, ServletException {
+        String redirectUrlAfterSocialLogin = rq.getCookieValue("redirectUrlAfterSocialLogin", "");
+
+        String accessToken = authTokenService.genAccessToken(rq.getMember());
+        String refreshToken = rq.getMember().getRefreshToken();
+
+        rq.destroySession();
+        rq.setCrossDomainCookie("accessToken", accessToken);
+        rq.setCrossDomainCookie("refreshToken", refreshToken);
+        rq.removeCookie("redirectUrlAfterSocialLogin");
+
+        response.sendRedirect(redirectUrlAfterSocialLogin);
+        return;
+    }
+}

--- a/src/main/java/com/ll/eitcharge/global/security/CustomOAuth2UserService.java
+++ b/src/main/java/com/ll/eitcharge/global/security/CustomOAuth2UserService.java
@@ -1,0 +1,39 @@
+package com.ll.eitcharge.global.security;
+
+import com.ll.eitcharge.domain.member.member.entity.Member;
+import com.ll.eitcharge.domain.member.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberService memberService;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String oauthId = oAuth2User.getName();
+        String providerTypeCode = userRequest.getClientRegistration().getRegistrationId().toUpperCase();
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+        Map attributesProperties = (Map) attributes.get("properties");
+
+        String nickname = (String) attributesProperties.get("nickname");
+        String profileImgUrl = (String) attributesProperties.get("profile_image");
+        String username = providerTypeCode + "__%s".formatted(oauthId);
+        Member member = memberService.modifyOrJoin(username, providerTypeCode, nickname, profileImgUrl).getData();
+
+        return new SecurityUser(member.getId(), member.getUsername(), member.getPassword(), member.getAuthorities());
+    }
+}

--- a/src/main/java/com/ll/eitcharge/global/security/SecurityConfig.java
+++ b/src/main/java/com/ll/eitcharge/global/security/SecurityConfig.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 @EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ASuccessHandler aSuccessHandler;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -25,6 +26,8 @@ public class SecurityConfig {
             .authorizeRequests(authorizeRequests ->
                 authorizeRequests
                     .requestMatchers("/gen/**")
+                    .permitAll()
+                    .anyRequest()
                     .permitAll()
             )
             .csrf(
@@ -35,6 +38,12 @@ public class SecurityConfig {
                     .sessionCreationPolicy(
                         SessionCreationPolicy.STATELESS
                     )
+            )
+            .oauth2Login(
+                    oauth2Login ->
+                            oauth2Login
+                                    .successHandler(aSuccessHandler)
+
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: dev
     include: secret
   servlet:
     multipart:
@@ -17,7 +17,7 @@ spring:
     #일단 설정은 mysql로 해놨습니다.
     url: jdbc:mysql://localhost:3306/eitcharge #디비 생성하시길...
     username: root
-    password: # custom password
+    password: lldj123414
     driver-class-name: com.mysql.cj.jdbc.Driver
   sql:
     init:


### PR DESCRIPTION
* feat: successhandler 추가

* feat: OAuth2SecurityConfig추가

* feat: kakao로그인 버튼

* feat : rq에 isFrontUrl, destroySession 메서드 추가

* feat: member엔티티에 nickname, profileImgUrl필드 추가

* feat: OAuth2UserService추가

* feat: socialMemberController추가

* feat : MemberService에 modifyOrJoin메서드 추가

* feat: CustomSuccessHandler

* remove: test메서드 삭제

* withCredential 추가

* remove: OAuth2SecurityConfig 삭제

* feat: Oauth2설정 추가

* feat: 카카오 로그인 완료

* feat: application.yml 설정 복귀

* feat: nickname으로 가져오기 & sessionStorage에 username넣기

* feat: successHandler 수정

* feat 수정