### PR TITLE
fix: TechnicalManager <-> ChargingStation 양방향 → 단방향 매핑으로 수정

### DIFF
--- a/src/main/java/com/ll/eitcharge/domain/chargingStation/chargingStation/entity/ChargingStation.java
+++ b/src/main/java/com/ll/eitcharge/domain/chargingStation/chargingStation/entity/ChargingStation.java
@@ -1,22 +1,26 @@
 package com.ll.eitcharge.domain.chargingStation.chargingStation.entity;
 
+import static jakarta.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import com.ll.eitcharge.domain.charger.charger.entity.Charger;
 import com.ll.eitcharge.domain.operatingCompany.operatingCompany.entity.OperatingCompany;
 import com.ll.eitcharge.domain.region.regionDetail.entity.RegionDetail;
 import com.ll.eitcharge.domain.report.report.entity.Report;
 import com.ll.eitcharge.domain.review.review.entity.Review;
-import com.ll.eitcharge.domain.technicalManager.technicalManager.entity.TechnicalManager;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static jakarta.persistence.FetchType.LAZY;
-import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -44,9 +48,6 @@ public class ChargingStation {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "busi_id")
     private OperatingCompany operatingCompany;
-
-    @OneToOne(fetch = LAZY, mappedBy = "chargingStation")
-    private TechnicalManager technicalManager;
 
     //충전소명
     private String statNm;


### PR DESCRIPTION
## 작업 내용
- [x]  TechnicalManager 의도하지 않은 쿼리 관련 N+1 문제 수정
    - [x]  OneToOne 양방향 -> 단방향 으로 연관관계 정정 (TechnicalManager가 ChargingStation FK 보유)
    - [x]  관련 도메인 신고, 충전소 지도 / 검색 테스트 확인 완료

## 참고 사항
- 관련 이슈 문서화 :  [OneToOne 양방향 관계에서 의도치 않은 N+1 문제 원인과 해결방안](https://www.notion.so/OneToOne-N-1-3142a6f473ad42499d78dd32812e7a18?pvs=4)
- close #102 